### PR TITLE
EditVinyl page for Admins

### DIFF
--- a/BLL/Interfaces/IGenreService.cs
+++ b/BLL/Interfaces/IGenreService.cs
@@ -7,10 +7,7 @@ public interface IGenreService
 {
     Task<List<GenreDto>> GetAllGenres();
     Task<GenreDto> GetGenresById(int genreId);
-    public IQueryable<VinylGenre> GetAllVinylGenres();
-    public void CreateVinylGenre(int VinylId, int GenreId);
     Task CreateGenre(GenreDto genreDto);
     Task UpdateGenre(GenreDto genreDto);
-    Task UpdateVinylGenreLink(int vinylId, int genreId);
     Task<bool> DeleteGenre(int id);
 }

--- a/BLL/Interfaces/IGenreService.cs
+++ b/BLL/Interfaces/IGenreService.cs
@@ -1,16 +1,16 @@
 using DataLayer.Models;
+using Shared.DTOs;
 
 namespace BLL.Interfaces;
 
 public interface IGenreService
 {
-    public IQueryable<Genre> GetAllGenres();
-    public IQueryable<Genre> GetGenresById(int genreId);
+    Task<List<GenreDto>> GetAllGenres();
+    Task<GenreDto> GetGenresById(int genreId);
     public IQueryable<VinylGenre> GetAllVinylGenres();
     public void CreateVinylGenre(int VinylId, int GenreId);
-    void CreateGenre(Genre genre);
-    void UpdateGenre(Genre genre);
+    Task CreateGenre(GenreDto genreDto);
+    Task UpdateGenre(GenreDto genreDto);
     Task UpdateVinylGenreLink(int vinylId, int genreId);
-    bool DeleteGenre(int genreId);
-
+    Task<bool> DeleteGenre(int id);
 }

--- a/BLL/Interfaces/IVinylService.cs
+++ b/BLL/Interfaces/IVinylService.cs
@@ -5,7 +5,7 @@ namespace BLL.Interfaces;
 
 public interface IVinylService
 {
-    void CreateVinyl(VinylDto vinylDto);
+    Vinyl CreateVinyl(VinylDto vinylDto);
     bool DeleteVinylById(int VinylId);
     VinylDto GetVinylById(int id);
     void UpdateVinylBy(int vinylId, VinylDto newVinylDTO);

--- a/BLL/Repositories/GenreService.cs
+++ b/BLL/Repositories/GenreService.cs
@@ -1,10 +1,12 @@
-using BLL.Interfaces;
-using DAL;
+using Shared.DTOs;
 using DataLayer.Models;
+using DAL;
 using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Threading.Tasks;
+using BLL.Interfaces;
 
 namespace BLL.Repositories;
-
 public class GenreService : IGenreService
 {
     private readonly EfDbContext _context;
@@ -13,74 +15,63 @@ public class GenreService : IGenreService
     {
         _context = melodyMineService;
     }
-    
-    public IQueryable<Genre> GetAllGenres()
+
+    public async Task<List<GenreDto>> GetAllGenres()
     {
-        IQueryable<Genre> tempGenres = _context.Genres.Distinct();
-        
-        return tempGenres;
+        return await _context.Genres
+            .Select(g => new GenreDto { GenreId = g.GenreId, GenreName = g.GenreName })
+            .ToListAsync();
     }
 
-    
-    public IQueryable<Genre> GetGenresById(int genreId)
+    public async Task<GenreDto> GetGenresById(int genreId)
     {
-        IQueryable<Genre> tempGenres = _context.Genres.Where(c => c.GenreId == genreId);
+        var genre = await _context.Genres.FindAsync(genreId);
+        if (genre == null) return null;
 
-        return tempGenres;
+        return new GenreDto { GenreId = genre.GenreId, GenreName = genre.GenreName };
     }
-    
+
+    public async Task CreateGenre(GenreDto genreDto)
+    {
+        var genre = new Genre { GenreName = genreDto.GenreName };
+        _context.Genres.Add(genre);
+        await _context.SaveChangesAsync();
+
+        genreDto.GenreId = genre.GenreId;
+    }
+
+    public async Task UpdateGenre(GenreDto genreDto)
+    {
+        var genre = await _context.Genres.FindAsync(genreDto.GenreId);
+        if (genre == null) return;
+
+        genre.GenreName = genreDto.GenreName;
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task<bool> DeleteGenre(int id)
+    {
+        var genre = await _context.Genres.FindAsync(id);
+        if (genre == null) return false;
+
+        _context.Genres.Remove(genre);
+        await _context.SaveChangesAsync();
+
+        return true;
+    }
+
     public IQueryable<VinylGenre> GetAllVinylGenres()
     {
-        IQueryable<VinylGenre> tempGenres = _context.VinylGenres;
-            
-        return tempGenres;
-    }
-    
-    public void CreateVinylGenre(int VinylId, int GenreId)
-    {
-        _context.VinylGenres.Add(new VinylGenre { VinylId = VinylId, GenreId = GenreId });
-        _context.SaveChanges();
-    }
-    
-    public void CreateGenre(Genre genre)
-    {
-        _context.Genres.Add(genre);
-        _context.SaveChanges();
-    }
-    
-    public void UpdateGenre(Genre genre)
-    {
-        var existingGenre = _context.Genres.Find(genre.GenreId);
-        if (existingGenre != null)
-        {
-            existingGenre.GenreName = genre.GenreName;
-            _context.SaveChanges();
-        }
+        throw new NotImplementedException();
     }
 
-    public bool DeleteGenre(int genreId)
+    public void CreateVinylGenre(int VinylId, int GenreId)
     {
-        var genre = _context.Genres.Find(genreId);
-        if (genre != null)
-        {
-            _context.Genres.Remove(genre);
-            _context.SaveChanges();
-            return true;
-        }
-        return false;
+        throw new NotImplementedException();
     }
-    
-    public async Task UpdateVinylGenreLink(int vinylId, int genreId)
+
+    public Task UpdateVinylGenreLink(int vinylId, int genreId)
     {
-        var vinyl = _context.Vinyls.Include(v => v.VinylGenres).FirstOrDefault(v => v.VinylId == vinylId);
-        if (vinyl.VinylGenres.Any())
-        {
-            vinyl.VinylGenres.Clear();
-        }
-        
-        var newVinylGenre = new VinylGenre { VinylId = vinylId, GenreId = genreId };
-        vinyl.VinylGenres.Add(newVinylGenre);
-        
-        await _context.SaveChangesAsync();
+        throw new NotImplementedException();
     }
 }

--- a/BLL/Repositories/GenreService.cs
+++ b/BLL/Repositories/GenreService.cs
@@ -59,19 +59,4 @@ public class GenreService : IGenreService
 
         return true;
     }
-
-    public IQueryable<VinylGenre> GetAllVinylGenres()
-    {
-        throw new NotImplementedException();
-    }
-
-    public void CreateVinylGenre(int VinylId, int GenreId)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task UpdateVinylGenreLink(int vinylId, int genreId)
-    {
-        throw new NotImplementedException();
-    }
 }

--- a/BLL/Repositories/VinylService.cs
+++ b/BLL/Repositories/VinylService.cs
@@ -76,6 +76,7 @@ public class VinylService : IVinylService
             vinyl.Artist = newVinylDTO.Artist;
             vinyl.Price = newVinylDTO.Price;
             vinyl.ImagePath = newVinylDTO.ImagePath;
+            vinyl.GenreId = newVinylDTO.GenreId;
             _context.SaveChanges();
         }
     }

--- a/BLL/Repositories/VinylService.cs
+++ b/BLL/Repositories/VinylService.cs
@@ -15,7 +15,7 @@ public class VinylService : IVinylService
         _context = context;
     }
 
-    public void CreateVinyl(VinylDto vinylDTO)
+    public Vinyl CreateVinyl(VinylDto vinylDTO)
     {
         var vinyl = new Vinyl
         {
@@ -28,6 +28,8 @@ public class VinylService : IVinylService
 
         _context.Vinyls.Add(vinyl);
         _context.SaveChanges();
+
+        return vinyl;
     }
 
     public bool DeleteVinylById(int vinylId)

--- a/DAL/Entities/Genre.cs
+++ b/DAL/Entities/Genre.cs
@@ -5,10 +5,10 @@ namespace DataLayer.Models;
 public class Genre
 {
     public int GenreId { get; set; }
-    
+
     [Required(ErrorMessage = "Genre name is required.")]
     public string GenreName { get; set; }
-    
+
     // Navigation property
-    public ICollection<VinylGenre> VinylGenres { get; set; }
+    public ICollection<Vinyl> Vinyls { get; set; }
 }

--- a/DAL/Entities/Vinyl.cs
+++ b/DAL/Entities/Vinyl.cs
@@ -6,24 +6,22 @@ namespace DataLayer.Models;
 public class Vinyl
 {
     public int VinylId { get; set; }
-    
+
     [Required(ErrorMessage = "Title is required")]
-    public string Title { get; set; } 
-    
+    public string Title { get; set; }
+
     [Required(ErrorMessage = "Artist is required")]
     public string? Artist { get; set; }
-    
+
     [Required(ErrorMessage = "Price is required")]
     [Range(0.01, double.MaxValue, ErrorMessage = "Price must be greater than 0")]
     public decimal Price { get; set; }
-    
+
     [Required(ErrorMessage = "Image path is required")]
     public string ImagePath { get; set; }
-    
+
     [Required(ErrorMessage = "Genre is required")]
-    public int? GenreId { get; set; }
+    public int GenreId { get; set; }
 
-
-    // Navigation properties
-    public ICollection<VinylGenre>? VinylGenres { get; set; }
+    public Genre Genre { get; set; } // Navigation property
 }

--- a/DAL/Migrations/20231122080849_AddDataSeeding.Designer.cs
+++ b/DAL/Migrations/20231122080849_AddDataSeeding.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DAL;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DAL.Migrations
 {
     [DbContext(typeof(EfDbContext))]
-    partial class EfDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231122080849_AddDataSeeding")]
+    partial class AddDataSeeding
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DAL/Migrations/20231122080849_AddDataSeeding.cs
+++ b/DAL/Migrations/20231122080849_AddDataSeeding.cs
@@ -1,0 +1,243 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDataSeeding : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Addresses",
+                columns: table => new
+                {
+                    AddressId = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Postal = table.Column<int>(type: "integer", nullable: false),
+                    StreetNumber = table.Column<int>(type: "integer", nullable: false),
+                    City = table.Column<string>(type: "text", nullable: false),
+                    Country = table.Column<string>(type: "text", nullable: false),
+                    Street = table.Column<string>(type: "text", nullable: false),
+                    CardNumber = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Addresses", x => x.AddressId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Genres",
+                columns: table => new
+                {
+                    GenreId = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    GenreName = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Genres", x => x.GenreId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Vinyls",
+                columns: table => new
+                {
+                    VinylId = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Title = table.Column<string>(type: "text", nullable: false),
+                    Artist = table.Column<string>(type: "text", nullable: false),
+                    Price = table.Column<decimal>(type: "numeric", nullable: false),
+                    ImagePath = table.Column<string>(type: "text", nullable: false),
+                    GenreId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Vinyls", x => x.VinylId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Orders",
+                columns: table => new
+                {
+                    OrderId = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Email = table.Column<string>(type: "text", nullable: false),
+                    BuyDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "NOW()"),
+                    AddressId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Orders", x => x.OrderId);
+                    table.ForeignKey(
+                        name: "FK_Orders_Addresses_AddressId",
+                        column: x => x.AddressId,
+                        principalTable: "Addresses",
+                        principalColumn: "AddressId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "VinylGenres",
+                columns: table => new
+                {
+                    VinylId = table.Column<int>(type: "integer", nullable: false),
+                    GenreId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_VinylGenres", x => new { x.VinylId, x.GenreId });
+                    table.ForeignKey(
+                        name: "FK_VinylGenres_Genres_GenreId",
+                        column: x => x.GenreId,
+                        principalTable: "Genres",
+                        principalColumn: "GenreId",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_VinylGenres_Vinyls_VinylId",
+                        column: x => x.VinylId,
+                        principalTable: "Vinyls",
+                        principalColumn: "VinylId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OrderProductDetails",
+                columns: table => new
+                {
+                    OrderProductDetailsId = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    VinylId = table.Column<int>(type: "integer", nullable: false),
+                    Price = table.Column<decimal>(type: "numeric", nullable: false),
+                    Quantity = table.Column<int>(type: "integer", nullable: false),
+                    OrderId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OrderProductDetails", x => x.OrderProductDetailsId);
+                    table.ForeignKey(
+                        name: "FK_OrderProductDetails_Orders_OrderId",
+                        column: x => x.OrderId,
+                        principalTable: "Orders",
+                        principalColumn: "OrderId",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_OrderProductDetails_Vinyls_VinylId",
+                        column: x => x.VinylId,
+                        principalTable: "Vinyls",
+                        principalColumn: "VinylId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.InsertData(
+                table: "Addresses",
+                columns: new[] { "AddressId", "CardNumber", "City", "Country", "Postal", "Street", "StreetNumber" },
+                values: new object[,]
+                {
+                    { 1, "4111 1111 1111 1111", "Copenhagen", "Denmark", 2400, "Birkedommervej", 29 },
+                    { 2, "4111 1111 1111 1112", "Fredericia", "Denmark", 7000, "Dronningsgade", 8 }
+                });
+
+            migrationBuilder.InsertData(
+                table: "Genres",
+                columns: new[] { "GenreId", "GenreName" },
+                values: new object[,]
+                {
+                    { 1, "Alternative" },
+                    { 2, "HipHop" },
+                    { 3, "Pop" },
+                    { 4, "Christmas" }
+                });
+
+            migrationBuilder.InsertData(
+                table: "Vinyls",
+                columns: new[] { "VinylId", "Artist", "GenreId", "ImagePath", "Price", "Title" },
+                values: new object[,]
+                {
+                    { 1, "Ukendt Kunstner", 2, "https://moby-disc.dk/media/catalog/product/cache/e7dc67195437dd6c7bf40d88e25a85ce/i/m/image001_9__2.jpg", 127m, "Dansktop" },
+                    { 2, "Kanye West", 2, "https://moby-disc.dk/media/catalog/product/cache/e7dc67195437dd6c7bf40d88e25a85ce/k/a/kanye-west-2018-ye-compact-disc.jpg", 187m, "Ye" },
+                    { 3, "Radiohead", 1, "https://moby-disc.dk/media/catalog/product/cache/e7dc67195437dd6c7bf40d88e25a85ce/b/f/bfea3555ad38fe476532c5b54f218c09_1.jpg", 227m, "OK Computer" },
+                    { 4, "Frank Ocean", 3, "https://best-fit.transforms.svdcdn.com/production/albums/frank-ocean-blond-compressed-0933daea-f052-40e5-85a4-35e07dac73df.jpg?w=469&h=469&q=100&auto=format&fit=crop&dm=1643652677&s=6ef41cb2628eb28d736e27b42635b66e", 777m, "Blonde" },
+                    { 5, "Dean Martin", 4, "https://moby-disc.dk/media/catalog/product/cache/e7dc67195437dd6c7bf40d88e25a85ce/m/o/moby-disc-13-09-2023_10.54.44.png", 127m, "Winter Wonderland" }
+                });
+
+            migrationBuilder.InsertData(
+                table: "Orders",
+                columns: new[] { "OrderId", "AddressId", "BuyDate", "Email" },
+                values: new object[,]
+                {
+                    { 1, 1, new DateTime(2023, 11, 22, 8, 8, 49, 509, DateTimeKind.Utc).AddTicks(8340), "john@example.com" },
+                    { 2, 2, new DateTime(2023, 11, 22, 8, 8, 49, 509, DateTimeKind.Utc).AddTicks(8340), "adrian@example.com" }
+                });
+
+            migrationBuilder.InsertData(
+                table: "VinylGenres",
+                columns: new[] { "GenreId", "VinylId" },
+                values: new object[,]
+                {
+                    { 1, 1 },
+                    { 2, 2 },
+                    { 2, 3 },
+                    { 3, 4 },
+                    { 4, 5 }
+                });
+
+            migrationBuilder.InsertData(
+                table: "OrderProductDetails",
+                columns: new[] { "OrderProductDetailsId", "OrderId", "Price", "Quantity", "VinylId" },
+                values: new object[,]
+                {
+                    { 1, 1, 127m, 0, 1 },
+                    { 2, 2, 187m, 0, 2 }
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrderProductDetails_OrderId",
+                table: "OrderProductDetails",
+                column: "OrderId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrderProductDetails_VinylId",
+                table: "OrderProductDetails",
+                column: "VinylId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Orders_AddressId",
+                table: "Orders",
+                column: "AddressId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VinylGenres_GenreId",
+                table: "VinylGenres",
+                column: "GenreId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OrderProductDetails");
+
+            migrationBuilder.DropTable(
+                name: "VinylGenres");
+
+            migrationBuilder.DropTable(
+                name: "Orders");
+
+            migrationBuilder.DropTable(
+                name: "Genres");
+
+            migrationBuilder.DropTable(
+                name: "Vinyls");
+
+            migrationBuilder.DropTable(
+                name: "Addresses");
+        }
+    }
+}

--- a/DAL/Migrations/20231122114322_UpdateModels.Designer.cs
+++ b/DAL/Migrations/20231122114322_UpdateModels.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DAL;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DAL.Migrations
 {
     [DbContext(typeof(EfDbContext))]
-    partial class EfDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231122114322_UpdateModels")]
+    partial class UpdateModels
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -278,14 +281,14 @@ namespace DAL.Migrations
                         {
                             OrderId = 1,
                             AddressId = 1,
-                            BuyDate = new DateTime(2023, 11, 22, 12, 27, 37, 638, DateTimeKind.Utc).AddTicks(1490),
+                            BuyDate = new DateTime(2023, 11, 22, 11, 43, 22, 155, DateTimeKind.Utc).AddTicks(7230),
                             Email = "john@example.com"
                         },
                         new
                         {
                             OrderId = 2,
                             AddressId = 2,
-                            BuyDate = new DateTime(2023, 11, 22, 12, 27, 37, 638, DateTimeKind.Utc).AddTicks(1490),
+                            BuyDate = new DateTime(2023, 11, 22, 11, 43, 22, 155, DateTimeKind.Utc).AddTicks(7230),
                             Email = "adrian@example.com"
                         });
                 });

--- a/DAL/Migrations/20231122114322_UpdateModels.cs
+++ b/DAL/Migrations/20231122114322_UpdateModels.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateModels : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "VinylGenres");
+
+            migrationBuilder.UpdateData(
+                table: "Orders",
+                keyColumn: "OrderId",
+                keyValue: 1,
+                column: "BuyDate",
+                value: new DateTime(2023, 11, 22, 11, 43, 22, 155, DateTimeKind.Utc).AddTicks(7230));
+
+            migrationBuilder.UpdateData(
+                table: "Orders",
+                keyColumn: "OrderId",
+                keyValue: 2,
+                column: "BuyDate",
+                value: new DateTime(2023, 11, 22, 11, 43, 22, 155, DateTimeKind.Utc).AddTicks(7230));
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Vinyls_GenreId",
+                table: "Vinyls",
+                column: "GenreId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Vinyls_Genres_GenreId",
+                table: "Vinyls",
+                column: "GenreId",
+                principalTable: "Genres",
+                principalColumn: "GenreId",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Vinyls_Genres_GenreId",
+                table: "Vinyls");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Vinyls_GenreId",
+                table: "Vinyls");
+
+            migrationBuilder.CreateTable(
+                name: "VinylGenres",
+                columns: table => new
+                {
+                    VinylId = table.Column<int>(type: "integer", nullable: false),
+                    GenreId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_VinylGenres", x => new { x.VinylId, x.GenreId });
+                    table.ForeignKey(
+                        name: "FK_VinylGenres_Genres_GenreId",
+                        column: x => x.GenreId,
+                        principalTable: "Genres",
+                        principalColumn: "GenreId",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_VinylGenres_Vinyls_VinylId",
+                        column: x => x.VinylId,
+                        principalTable: "Vinyls",
+                        principalColumn: "VinylId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.UpdateData(
+                table: "Orders",
+                keyColumn: "OrderId",
+                keyValue: 1,
+                column: "BuyDate",
+                value: new DateTime(2023, 11, 22, 8, 8, 49, 509, DateTimeKind.Utc).AddTicks(8340));
+
+            migrationBuilder.UpdateData(
+                table: "Orders",
+                keyColumn: "OrderId",
+                keyValue: 2,
+                column: "BuyDate",
+                value: new DateTime(2023, 11, 22, 8, 8, 49, 509, DateTimeKind.Utc).AddTicks(8340));
+
+            migrationBuilder.InsertData(
+                table: "VinylGenres",
+                columns: new[] { "GenreId", "VinylId" },
+                values: new object[,]
+                {
+                    { 1, 1 },
+                    { 2, 2 },
+                    { 2, 3 },
+                    { 3, 4 },
+                    { 4, 5 }
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VinylGenres_GenreId",
+                table: "VinylGenres",
+                column: "GenreId");
+        }
+    }
+}

--- a/DAL/Migrations/20231122122737_RemoveRequiredGenre.Designer.cs
+++ b/DAL/Migrations/20231122122737_RemoveRequiredGenre.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DAL;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DAL.Migrations
 {
     [DbContext(typeof(EfDbContext))]
-    partial class EfDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231122122737_RemoveRequiredGenre")]
+    partial class RemoveRequiredGenre
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DAL/Migrations/20231122122737_RemoveRequiredGenre.cs
+++ b/DAL/Migrations/20231122122737_RemoveRequiredGenre.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveRequiredGenre : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "Orders",
+                keyColumn: "OrderId",
+                keyValue: 1,
+                column: "BuyDate",
+                value: new DateTime(2023, 11, 22, 12, 27, 37, 638, DateTimeKind.Utc).AddTicks(1490));
+
+            migrationBuilder.UpdateData(
+                table: "Orders",
+                keyColumn: "OrderId",
+                keyValue: 2,
+                column: "BuyDate",
+                value: new DateTime(2023, 11, 22, 12, 27, 37, 638, DateTimeKind.Utc).AddTicks(1490));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "Orders",
+                keyColumn: "OrderId",
+                keyValue: 1,
+                column: "BuyDate",
+                value: new DateTime(2023, 11, 22, 11, 43, 22, 155, DateTimeKind.Utc).AddTicks(7230));
+
+            migrationBuilder.UpdateData(
+                table: "Orders",
+                keyColumn: "OrderId",
+                keyValue: 2,
+                column: "BuyDate",
+                value: new DateTime(2023, 11, 22, 11, 43, 22, 155, DateTimeKind.Utc).AddTicks(7230));
+        }
+    }
+}

--- a/Shared/DTOs/VinylDto.cs
+++ b/Shared/DTOs/VinylDto.cs
@@ -13,5 +13,7 @@ public class VinylDto
     public decimal Price { get; set; }
     [Required]
     public string ImagePath { get; set; }
-    public List<GenreDto> Genres { get; set; }
+
+    public string GenreName { get; set; }
+    public int GenreId { get; set; }
 }

--- a/Shared/DTOs/VinylDto.cs
+++ b/Shared/DTOs/VinylDto.cs
@@ -1,11 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Shared.DTOs;
 
 public class VinylDto
 {
     public int VinylId { get; set; }
+    [Required]
     public string Title { get; set; }
+    [Required]
     public string? Artist { get; set; }
+    [Required]
     public decimal Price { get; set; }
+    [Required]
     public string ImagePath { get; set; }
     public List<GenreDto> Genres { get; set; }
 }

--- a/Shared/DTOs/VinylDto.cs
+++ b/Shared/DTOs/VinylDto.cs
@@ -14,6 +14,6 @@ public class VinylDto
     [Required]
     public string ImagePath { get; set; }
 
-    public string GenreName { get; set; }
+    public string? GenreName { get; set; }
     public int GenreId { get; set; }
 }

--- a/UI/Pages/Admin.razor
+++ b/UI/Pages/Admin.razor
@@ -39,12 +39,11 @@
         Administrate Entities
     </button>
     <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-        <NavLink class="dropdown-item" href="/EditVinyls">Vinyls</NavLink>
-        <NavLink class="dropdown-item" href="/EditOrders">Orders</NavLink>
-        <NavLink class="dropdown-item" href="/EditGenres">Genres</NavLink>
+        <NavLink class="dropdown-item" href="/VinylOverview">Vinyls</NavLink>
+        <NavLink class="dropdown-item" href="/OrderOverview">Orders</NavLink>
+        <NavLink class="dropdown-item" href="/GenreOverview">Genres</NavLink>
     </div>
 </div>
 
 @code {
-
 }

--- a/UI/Pages/EditVinyl.razor
+++ b/UI/Pages/EditVinyl.razor
@@ -6,34 +6,58 @@
 @using System.Text.Json;
 
 <h3>Edit Vinyl</h3>
-<h3>Edit Vinyl</h3>
 
 @if (vinyl != null)
 {
     <EditForm Model="vinyl" OnValidSubmit="HandleValidSubmit">
-    <DataAnnotationsValidator />
-    <ValidationSummary />
+        <DataAnnotationsValidator />
+        <ValidationSummary />
+        <div class="form-group fw-bold">
+            <label for="title">Album</label>
+            <InputText id="title" @bind-Value="vinyl.Title" class="form-control" placeholder="Enter vinyl name" />
+            <ValidationMessage For="@(() => vinyl.Title)" class="text-danger" />
+        </div>
 
-    <InputText id="title" @bind-Value="vinyl.Title" />
-    <InputText id="artist" @bind-Value="vinyl.Artist" />
-    <InputNumber id="price" @bind-Value="vinyl.Price" />
-    <InputText id="imagePath" @bind-Value="vinyl.ImagePath" />
-    <InputSelect id="genreId" @bind-Value="vinyl.GenreId">
-        @foreach (var genre in genres)
-            {
-                <option value="@genre.GenreId">@genre.GenreName</option>
-            }
-        </InputSelect>
+        <div class="form-group fw-bold">
+            <label for="artist">Artist</label>
+            <InputText id="artist" @bind-Value="vinyl.Artist" class="form-control" placeholder="Enter artist name" />
+            <ValidationMessage For="@(() => vinyl.Artist)" class="text-danger" />
+        </div>
 
-        <button type="submit">Submit</button>
+        <div class="form-group fw-bold">
+            <label for="price">Price</label>
+            <InputNumber id="price" @bind-Value="vinyl.Price" class="form-control" placeholder="Enter price" />
+            <ValidationMessage For="@(() => vinyl.Price)" class="text-danger" />
+        </div>
+
+        <div class="form-group fw-bold">
+            <label for="imagePath">Image</label>
+            <InputText id="imagePath" @bind-Value="vinyl.ImagePath" class="form-control" placeholder="Enter image path" />
+            <ValidationMessage For="@(() => vinyl.ImagePath)" class="text-danger" />
+        </div>
+
+        <div class="form-group fw-bold">
+            <label for="genreId">Genre</label>
+            <InputSelect id="genreId" @bind-Value="vinyl.GenreId" class="form-control">
+                <option value="">-- Select a Genre --</option>
+                @foreach (var genre in genres)
+                {
+                    <option value="@genre.GenreId">@genre.GenreName</option>
+                }
+            </InputSelect>
+            <ValidationMessage For="@(() => vinyl.GenreId)" class="text-danger" />
+        </div>
+
+        <div class="button-group">
+            <button type="submit" class="btn btn-primary mt-1">Update Vinyl</button>
+            <button class="btn btn-secondary mt-1" @onclick="Back">Back</button>
+        </div>
     </EditForm>
 }
 else
 {
     <p>Loading...</p>
 }
-
-<button @onclick="Back">Back</button>
 
 @code {
     [Parameter]
@@ -65,6 +89,7 @@ else
         if (response.IsSuccessStatusCode)
         {
             vinyl = await Http.GetFromJsonAsync<VinylDto>("api/vinyls/" + VinylId);
+            NavManager.NavigateTo("/VinylOverview");
         }
         else
         {

--- a/UI/Pages/EditVinyl.razor
+++ b/UI/Pages/EditVinyl.razor
@@ -1,7 +1,80 @@
-﻿@page "/EditVinyl"
+﻿@page "/EditVinyl/{VinylId}"
+@inject HttpClient Http
+@inject NavigationManager NavManager
+@using global::Shared.DTOs;
+@using Microsoft.AspNetCore.Components.Forms;
+@using System.Text.Json;
 
-<h3>EditVinyl</h3>
+<h3>Edit Vinyl</h3>
+<h3>Edit Vinyl</h3>
+
+@if (vinyl != null)
+{
+    <EditForm Model="vinyl" OnValidSubmit="HandleValidSubmit">
+    <DataAnnotationsValidator />
+    <ValidationSummary />
+
+    <InputText id="title" @bind-Value="vinyl.Title" />
+    <InputText id="artist" @bind-Value="vinyl.Artist" />
+    <InputNumber id="price" @bind-Value="vinyl.Price" />
+    <InputText id="imagePath" @bind-Value="vinyl.ImagePath" />
+    <InputSelect id="genreId" @bind-Value="vinyl.GenreId">
+        @foreach (var genre in genres)
+            {
+                <option value="@genre.GenreId">@genre.GenreName</option>
+            }
+        </InputSelect>
+
+        <button type="submit">Submit</button>
+    </EditForm>
+}
+else
+{
+    <p>Loading...</p>
+}
+
+<button @onclick="Back">Back</button>
 
 @code {
+    [Parameter]
+    public string VinylId { get; set; }
 
+    VinylDto vinyl;
+    List<GenreDto> genres;
+
+    protected override async Task OnInitializedAsync()
+    {
+        int vinylId = int.Parse(VinylId);
+
+        var response = await Http.GetAsync("api/Genres");
+        if (response.IsSuccessStatusCode)
+        {
+            var responseBody = await response.Content.ReadAsStringAsync();
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            genres = JsonSerializer.Deserialize<List<GenreDto>>(responseBody, options);
+        }
+
+        vinyl = await Http.GetFromJsonAsync<VinylDto>("api/vinyls/" + VinylId);
+    }
+
+    private async Task HandleValidSubmit()
+    {
+        Console.WriteLine(JsonSerializer.Serialize(vinyl));
+
+        var response = await Http.PutAsJsonAsync("api/vinyls/" + vinyl.VinylId, vinyl);
+        if (response.IsSuccessStatusCode)
+        {
+            vinyl = await Http.GetFromJsonAsync<VinylDto>("api/vinyls/" + VinylId);
+        }
+        else
+        {
+            var errorResponse = await response.Content.ReadAsStringAsync();
+            Console.WriteLine(errorResponse);
+        }
+    }
+
+    void Back()
+    {
+        NavManager.NavigateTo("/VinylOverview");
+    }
 }

--- a/UI/Pages/EditVinyl.razor
+++ b/UI/Pages/EditVinyl.razor
@@ -1,0 +1,7 @@
+﻿@page "/EditVinyl"
+
+<h3>EditVinyl</h3>
+
+@code {
+
+}

--- a/UI/Pages/Shop.razor
+++ b/UI/Pages/Shop.razor
@@ -47,15 +47,8 @@
 
     protected override async Task OnInitializedAsync()
     {
-        try
-        {
-            _vinyls = await HttpClient.GetFromJsonAsync<List<VinylDto>>("api/vinyls");
-            await GetVinyls(currentPage);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, ex.Message);
-        }
+        _vinyls = await HttpClient.GetFromJsonAsync<List<VinylDto>>("api/vinyls");
+        await GetVinyls(currentPage);
     }
 
     private async Task GetVinyls(int page, string sortField = null, bool sortAscending = true)

--- a/UI/Pages/VinylOverview.razor
+++ b/UI/Pages/VinylOverview.razor
@@ -105,7 +105,6 @@ else
         _vinyls = await Http.GetFromJsonAsync<VinylDto[]>("api/vinyls");
     }
 
-    // TODO: Fix the bug where the new vinyl is not added to the list
     private async Task HandleSubmit()
     {
         Console.WriteLine(JsonSerializer.Serialize(newVinyl));

--- a/UI/Pages/VinylOverview.razor
+++ b/UI/Pages/VinylOverview.razor
@@ -12,25 +12,26 @@
 
     <div class="form-group">
         <label for="title">Title:</label>
-        <InputText id="title" @bind-Value="newVinyl.Title" class="form-control" />
+        <InputText id="title" @bind-Value="newVinyl.Title" class="form-control" placeholder="Enter vinyl name" />
         <ValidationMessage For="@(() => newVinyl.Title)" />
     </div>
 
     <div class="form-group">
         <label for="artist">Artist:</label>
-        <InputText id="artist" @bind-Value="newVinyl.Artist" class="form-control" />
+        <InputText id="artist" @bind-Value="newVinyl.Artist" class="form-control" placeholder="Enter artist" />
         <ValidationMessage For="@(() => newVinyl.Artist)" />
     </div>
 
     <div class="form-group">
         <label for="price">Price:</label>
-        <InputNumber id="price" @bind-Value="newVinyl.Price" class="form-control" />
+        <InputNumber id="price" @bind-Value="newVinyl.Price" class="form-control" placeholder="Enter price" />
         <ValidationMessage For="@(() => newVinyl.Price)" />
     </div>
 
     <div class="form-group">
         <label for="imagePath">Image Path:</label>
-        <InputText id="imagePath" @bind-Value="newVinyl.ImagePath" class="form-control" />
+        <InputText id="imagePath" @bind-Value="newVinyl.ImagePath" class="form-control"
+            placeholder="Enter image path" />
         <ValidationMessage For="@(() => newVinyl.ImagePath)" />
     </div>
 
@@ -113,7 +114,7 @@ else
         if (response.IsSuccessStatusCode)
         {
             _vinyls = await Http.GetFromJsonAsync<VinylDto[]>("api/vinyls");
-            newVinyl = new VinylDto(); 
+            newVinyl = new VinylDto();
         }
         else
         {

--- a/UI/Pages/VinylOverview.razor
+++ b/UI/Pages/VinylOverview.razor
@@ -113,6 +113,7 @@ else
         if (response.IsSuccessStatusCode)
         {
             _vinyls = await Http.GetFromJsonAsync<VinylDto[]>("api/vinyls");
+            newVinyl = new VinylDto();
         }
         else
         {

--- a/UI/Pages/VinylOverview.razor
+++ b/UI/Pages/VinylOverview.razor
@@ -113,7 +113,7 @@ else
         if (response.IsSuccessStatusCode)
         {
             _vinyls = await Http.GetFromJsonAsync<VinylDto[]>("api/vinyls");
-            newVinyl = new VinylDto();
+            newVinyl = new VinylDto(); 
         }
         else
         {
@@ -125,6 +125,7 @@ else
 
     private void UpdateVinyl(int id)
     {
+        Console.WriteLine($"Navigating to edit page for vinyl with ID: {id}");
         NavigationManager.NavigateTo($"/editvinyl/{id}");
     }
 

--- a/UI/Pages/VinylOverview.razor
+++ b/UI/Pages/VinylOverview.razor
@@ -1,0 +1,136 @@
+﻿@page "/VinylOverview"
+@inject HttpClient Http
+@inject NavigationManager NavigationManager;
+@using global::Shared.DTOs;
+@using Microsoft.AspNetCore.Components.Forms;
+@using System.Text.Json;
+
+<h3>Overview of Vinyls</h3>
+
+<EditForm Model="newVinyl" OnValidSubmit="HandleSubmit">
+    <DataAnnotationsValidator />
+
+    <div class="form-group">
+        <label for="title">Title:</label>
+        <InputText id="title" @bind-Value="newVinyl.Title" class="form-control" />
+        <ValidationMessage For="@(() => newVinyl.Title)" />
+    </div>
+
+    <div class="form-group">
+        <label for="artist">Artist:</label>
+        <InputText id="artist" @bind-Value="newVinyl.Artist" class="form-control" />
+        <ValidationMessage For="@(() => newVinyl.Artist)" />
+    </div>
+
+    <div class="form-group">
+        <label for="price">Price:</label>
+        <InputNumber id="price" @bind-Value="newVinyl.Price" class="form-control" />
+        <ValidationMessage For="@(() => newVinyl.Price)" />
+    </div>
+
+    <div class="form-group">
+        <label for="imagePath">Image Path:</label>
+        <InputText id="imagePath" @bind-Value="newVinyl.ImagePath" class="form-control" />
+        <ValidationMessage For="@(() => newVinyl.ImagePath)" />
+    </div>
+
+    <div class="form-group">
+        <label for="genre">Genre:</label>
+        <InputSelect id="genre" @bind-Value="newVinyl.GenreId" class="form-control">
+            <option value="">Select a genre...</option>
+            @foreach (var genre in _genres)
+            {
+                <option value="@genre.GenreId">@genre.GenreName</option>
+            }
+        </InputSelect>
+        <ValidationMessage For="@(() => newVinyl.GenreId)" />
+    </div>
+
+    <button type="submit" class="btn btn-primary mt-1">Add New Vinyl</button>
+    <button class="btn btn-secondary mt-1" @onclick='() => NavigationManager.NavigateTo("/Admin")'>Back</button>
+</EditForm>
+
+@if (_vinyls == null)
+{
+    <p><em>Loading...</em></p>
+}
+else
+{
+    <table class="table">
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Title</th>
+            <th>Artist</th>
+            <th>Price</th>
+            <th>Genre</th>
+            <th>Actions</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var vinyl in _vinyls)
+            {
+                <tr>
+                    <td>@vinyl.VinylId</td>
+                    <td>@vinyl.Title</td>
+                    <td>@vinyl.Artist</td>
+                    <td>@vinyl.Price</td>
+                    <td>@vinyl.GenreName</td>
+                    <td>
+                        <button class="btn btn-primary" @onclick="() => UpdateVinyl(vinyl.VinylId)">Edit</button>
+                        <button class="btn btn-danger" @onclick="() => DeleteVinyl(vinyl.VinylId)">Delete</button>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+@code {
+    private List<GenreDto> _genres = new List<GenreDto>();
+    private VinylDto[] _vinyls;
+    private VinylDto newVinyl = new VinylDto();
+
+    protected override async Task OnInitializedAsync()
+    {
+        var response = await Http.GetAsync("api/Genres");
+        if (response.IsSuccessStatusCode)
+        {
+            var responseBody = await response.Content.ReadAsStringAsync();
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            _genres = JsonSerializer.Deserialize<List<GenreDto>>(responseBody, options);
+        }
+
+        _vinyls = await Http.GetFromJsonAsync<VinylDto[]>("api/vinyls");
+    }
+
+    // TODO: Fix the bug where the new vinyl is not added to the list
+    private async Task HandleSubmit()
+    {
+        Console.WriteLine(JsonSerializer.Serialize(newVinyl));
+
+        var response = await Http.PostAsJsonAsync("api/vinyls", newVinyl);
+        if (response.IsSuccessStatusCode)
+        {
+            _vinyls = await Http.GetFromJsonAsync<VinylDto[]>("api/vinyls");
+        }
+        else
+        {
+            // Log the server's response
+            var errorResponse = await response.Content.ReadAsStringAsync();
+            Console.WriteLine(errorResponse);
+        }
+    }
+
+    private void UpdateVinyl(int id)
+    {
+        NavigationManager.NavigateTo($"/editvinyl/{id}");
+    }
+
+    private async Task DeleteVinyl(int id)
+    {
+        var response = await Http.DeleteAsync($"api/vinyls/{id}");
+        _vinyls = await Http.GetFromJsonAsync<VinylDto[]>("api/vinyls");
+    }
+}

--- a/UI/Shared/NavMenu.razor
+++ b/UI/Shared/NavMenu.razor
@@ -1,6 +1,6 @@
 ﻿<div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
-        <a class="navbar-brand" href="">UI</a>
+        <a class="navbar-brand" href="">MelodyMine</a>
         <button title="Navigation menu" class="navbar-toggler" @onclick="ToggleNavMenu">
             <span class="navbar-toggler-icon"></span>
         </button>

--- a/UI/Shared/NavMenu.razor
+++ b/UI/Shared/NavMenu.razor
@@ -24,6 +24,11 @@
                 <span class="oi oi-person" aria-hidden="true"></span> Admin
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="shoppingcart">
+                <span class="oi oi-cart" aria-hidden="true"></span> Shopping cart
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/UI/Shared/NavMenu.razor
+++ b/UI/Shared/NavMenu.razor
@@ -16,7 +16,12 @@
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="vinyls">
-                <span class="oi oi-plus" aria-hidden="true"></span> Vinyls
+                <span class="oi oi-musical-note" aria-hidden="true"></span> Vinyls
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="admin">
+                <span class="oi oi-person" aria-hidden="true"></span> Admin
             </NavLink>
         </div>
     </nav>

--- a/WebAPI/Controllers/GenresController.cs
+++ b/WebAPI/Controllers/GenresController.cs
@@ -1,68 +1,77 @@
 using BLL.Interfaces;
-using DataLayer.Models;
+using Shared.DTOs;
 using Microsoft.AspNetCore.Mvc;
 
-namespace WebAPI.Controllers;
-
-[Route("api/[controller]")]
-[ApiController]
-public class GenresController : ControllerBase
+namespace WebAPI.Controllers
 {
-    private readonly IGenreService _genreService;
-
-    public GenresController(IGenreService genreService)
+    [Route("api/[controller]")]
+    [ApiController]
+    public class GenresController : ControllerBase
     {
-        _genreService = genreService;
-    }
+        private readonly IGenreService _genreService;
 
-    // GET: api/Genres
-    [HttpGet]
-    public ActionResult<List<Genre>> GetGenres()
-    {
-        return Ok(_genreService.GetAllGenres().ToList());
-    }
-
-    // GET: api/Genres/5
-    [HttpGet("{id}")]
-    public ActionResult<Genre> GetGenre(int id)
-    {
-        var genre = _genreService.GetGenresById(id).FirstOrDefault();
-        if (genre == null)
+        public GenresController(IGenreService genreService)
         {
-            return NotFound();
+            _genreService = genreService;
         }
-        return Ok(genre);
-    }
 
-    // POST: api/Genres
-    [HttpPost]
-    public ActionResult<Genre> PostGenre(Genre genre)
-    {
-        _genreService.CreateGenre(genre);
-        return CreatedAtAction(nameof(GetGenre), new { id = genre.GenreId }, genre);
-    }
-
-    // PUT: api/Genres/5
-    [HttpPut("{id}")]
-    public IActionResult PutGenre(int id, Genre genre)
-    {
-        if (id != genre.GenreId)
+        // GET: api/Genres
+        [HttpGet]
+        public async Task<ActionResult<List<GenreDto>>> GetGenres()
         {
-            return BadRequest();
+            var genres = await _genreService.GetAllGenres();
+            if (genres == null)
+            {
+                return NotFound();
+            }
+            return Ok(genres);
         }
-        _genreService.UpdateGenre(genre);
-        return NoContent();
-    }
 
-    // DELETE: api/Genres/5
-    [HttpDelete("{id}")]
-    public ActionResult<Genre> DeleteGenre(int id)
-    {
-        var success = _genreService.DeleteGenre(id);
-        if (!success)
+        // GET: api/Genres/5
+        [HttpGet("{id}")]
+        public async Task<ActionResult<GenreDto>> GetGenre(int id)
         {
-            return NotFound();
+            var genre = await _genreService.GetGenresById(id);
+            if (genre == null)
+            {
+                return NotFound();
+            }
+            return Ok(genre);
         }
-        return NoContent();
+
+        // POST: api/Genres
+        [HttpPost]
+        public async Task<ActionResult<GenreDto>> PostGenre(GenreDto genre)
+        {
+            await _genreService.CreateGenre(genre);
+            return CreatedAtAction(nameof(GetGenre), new { id = genre.GenreId }, genre);
+        }
+
+        // PUT: api/Genres/5
+        [HttpPut("{id}")]
+        public async Task<IActionResult> PutGenre(int id, GenreDto genre)
+        {
+            if (id != genre.GenreId)
+            {
+                return BadRequest();
+            }
+
+            await _genreService.UpdateGenre(genre);
+
+            return NoContent();
+        }
+
+        // DELETE: api/Genres/5
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteGenre(int id)
+        {
+            var success = await _genreService.DeleteGenre(id);
+            if (!success)
+            {
+                return NotFound();
+            }
+
+            return NoContent();
+        }
     }
 }

--- a/WebAPI/Controllers/VinylsController.cs
+++ b/WebAPI/Controllers/VinylsController.cs
@@ -29,7 +29,9 @@ namespace WebAPI.Controllers
                 Artist = vinyl.Artist,
                 Title = vinyl.Title,
                 Price = vinyl.Price,
-                ImagePath = vinyl.ImagePath
+                ImagePath = vinyl.ImagePath,
+                GenreId = vinyl.GenreId,
+                GenreName = vinyl.GenreName
             }).ToList();
 
             return Ok(vinylDTOs);
@@ -96,17 +98,7 @@ namespace WebAPI.Controllers
         [HttpPost]
         public ActionResult<VinylDto> CreateVinyl(VinylDto vinylDTO)
         {
-            var vinyl = new Vinyl
-            {
-                Artist = vinylDTO.Artist,
-                Title = vinylDTO.Title,
-                Price = vinylDTO.Price,
-                ImagePath = vinylDTO.ImagePath,
-                GenreId = vinylDTO.GenreId,
-                Genre = new Genre { GenreName = vinylDTO.GenreName }
-            };
-
-            _vinylService.CreateVinyl(vinylDTO);
+            var vinyl = _vinylService.CreateVinyl(vinylDTO);
 
             var newVinyl = new VinylDto
             {
@@ -115,8 +107,7 @@ namespace WebAPI.Controllers
                 Title = vinyl.Title,
                 Price = vinyl.Price,
                 ImagePath = vinyl.ImagePath,
-                GenreId = vinyl.GenreId,
-                GenreName = vinyl.Genre.GenreName
+                GenreId = vinyl.GenreId
             };
             return CreatedAtAction(nameof(GetVinyl), new { id = newVinyl.VinylId }, newVinyl);
         }

--- a/WebAPI/Controllers/VinylsController.cs
+++ b/WebAPI/Controllers/VinylsController.cs
@@ -101,21 +101,24 @@ namespace WebAPI.Controllers
                 Artist = vinylDTO.Artist,
                 Title = vinylDTO.Title,
                 Price = vinylDTO.Price,
-                ImagePath = vinylDTO.ImagePath
+                ImagePath = vinylDTO.ImagePath,
+                GenreId = vinylDTO.GenreId,
+                Genre = new Genre { GenreName = vinylDTO.GenreName }
             };
 
             _vinylService.CreateVinyl(vinylDTO);
 
-            var createdVinylDTO = new VinylDto
+            var newVinyl = new VinylDto
             {
                 VinylId = vinyl.VinylId,
                 Artist = vinyl.Artist,
                 Title = vinyl.Title,
                 Price = vinyl.Price,
-                ImagePath = vinyl.ImagePath
+                ImagePath = vinyl.ImagePath,
+                GenreId = vinyl.GenreId,
+                GenreName = vinyl.Genre.GenreName
             };
-
-            return CreatedAtAction(nameof(GetVinyl), new { id = createdVinylDTO.VinylId }, createdVinylDTO);
+            return CreatedAtAction(nameof(GetVinyl), new { id = newVinyl.VinylId }, newVinyl);
         }
     }
 }

--- a/WebAPI/Controllers/VinylsController.cs
+++ b/WebAPI/Controllers/VinylsController.cs
@@ -53,7 +53,9 @@ namespace WebAPI.Controllers
                 Artist = vinyl.Artist,
                 Title = vinyl.Title,
                 Price = vinyl.Price,
-                ImagePath = vinyl.ImagePath
+                ImagePath = vinyl.ImagePath,
+                GenreId = vinyl.GenreId,
+                GenreName = vinyl.GenreName
             };
 
             return Ok(vinylDTO);
@@ -61,23 +63,15 @@ namespace WebAPI.Controllers
 
         // PUT: api/Vinyls/{id}
         [HttpPut("{id}")]
-        public IActionResult UpdateVinyl(int id, VinylDto vinylDTO)
+        public IActionResult UpdateVinyl(int id, VinylDto vinylDto)
         {
-            if (id != vinylDTO.VinylId)
+            if (id != vinylDto.VinylId)
             {
                 return BadRequest();
             }
 
-            var vinyl = new Vinyl
-            {
-                VinylId = vinylDTO.VinylId,
-                Artist = vinylDTO.Artist,
-                Title = vinylDTO.Title,
-                Price = vinylDTO.Price,
-                ImagePath = vinylDTO.ImagePath
-            };
+            _vinylService.UpdateVinylBy(id, vinylDto);
 
-            _vinylService.UpdateVinylBy(id, vinylDTO);
             return NoContent();
         }
 


### PR DESCRIPTION
This pull request includes a wide range of changes across multiple files and directories. The most important changes include adding new migration files to update the database schema and data, improving the performance of the `GenreService` class by returning a list of DTOs instead of `IQueryable<Genre>`, and updating the `GenresController` and `VinylService` classes to use `GenreDto` instead of `Genre` for better separation of concerns.

Database schema and migration changes:

* <a href="diffhunk://#diff-f0566094dc69ec31e73c8916f5481ab27b9a9e96cd97d5dacea22aad142d69eaR1-R349">`DAL/Migrations/20231122114322_UpdateModels.Designer.cs`</a>: Added a new migration file that updates the database schema by adding new tables and setting up relationships between them.
* <a href="diffhunk://#diff-1c5c1d0f4b9168dd0cf6257bac1285e3b1e43daded8e724b0099b33f8f39934fR1-R243">`DAL/Migrations/20231122080849_AddDataSeeding.cs`</a>: Added a new migration file that sets up the initial database schema and data by creating tables and inserting initial data.
* <a href="diffhunk://#diff-19735d49212f1413d56271c2ba3b78989beea9bd81aa080d544ed3e0c8868ce0R1-R114">`DAL/Migrations/20231122114322_UpdateModels.cs`</a>: Added a new migration file that updates the database schema and data to reflect changes in the models.
* <a href="diffhunk://#diff-1e868236056d9d828372a3aae89095610920675dbb55b0824d69822724ef4861L118-L130">`DAL/EfDbContext.cs`</a>: Removed the `VinylGenres` table and its seeding, and changed the many-to-many relationship between `Vinyl` and `Genre` to a one-to-many relationship. <a href="diffhunk://#diff-1e868236056d9d828372a3aae89095610920675dbb55b0824d69822724ef4861L118-L130">[1]</a> <a href="diffhunk://#diff-1e868236056d9d828372a3aae89095610920675dbb55b0824d69822724ef4861L37-L48">[2]</a> <a href="diffhunk://#diff-1e868236056d9d828372a3aae89095610920675dbb55b0824d69822724ef4861L61-R60">[3]</a>

Service and controller changes:

* <a href="diffhunk://#diff-3fbd5d8c0e995ec3d4e3a1452d014215ecbede8a4fb7c5fa40568733a2e00432L17-R60">`BLL/Repositories/GenreService.cs`</a>: Changed the `GetAllGenres()` method to return a list of `GenreDto` objects instead of `IQueryable<Genre>`, improving performance by executing the query asynchronously and returning a list of DTOs. <a href="diffhunk://#diff-3fbd5d8c0e995ec3d4e3a1452d014215ecbede8a4fb7c5fa40568733a2e00432L17-R60">[1]</a> <a href="diffhunk://#diff-3fbd5d8c0e995ec3d4e3a1452d014215ecbede8a4fb7c5fa40568733a2e00432L1-L7">[2]</a>
* <a href="diffhunk://#diff-9810c22581822efaf24f1744b9f571bdb0a317524e7e95d2b1fc17f37dd48424L39-R77">`WebAPI/Controllers/GenresController.cs`</a>: Updated the `GenresController` class and the corresponding `GenreService` class to use `GenreDto` instead of `Genre` as the parameter type, improving separation of concerns and code consistency. <a href="diffhunk://#diff-9810c22581822efaf24f1744b9f571bdb0a317524e7e95d2b1fc17f37dd48424L39-R77">[1]</a> <a href="diffhunk://#diff-9810c22581822efaf24f1744b9f571bdb0a317524e7e95d2b1fc17f37dd48424L20-R34">[2]</a>
* <a href="diffhunk://#diff-f85de29e6240ad157c554a7fc3f6458b3f841008e21244d9e717f688ebc51e4fL118-R141">`BLL/Repositories/VinylService.cs`</a>: Made changes to the `VinylService` class and related methods to include genre information in the returned `VinylDto` objects, remove unnecessary code related to `VinylGenres`, and improve the efficiency of queries by eagerly loading the `Genre` property. <a href="diffhunk://#diff-f85de29e6240ad157c554a7fc3f6458b3f841008e21244d9e717f688ebc51e4fL118-R141">[1]</a> <a href="diffhunk://#diff-f85de29e6240ad157c554a7fc3f6458b3f841008e21244d9e717f688ebc51e4fL18-R32">[2]</a> <a href="diffhunk://#diff-f85de29e6240ad157c554a7fc3f6458b3f841008e21244d9e717f688ebc51e4fL216-R227">[3]</a> <a href="diffhunk://#diff-f85de29e6240ad157c554a7fc3f6458b3f841008e21244d9e717f688ebc51e4fR260-R261">[4]</a> <a href="diffhunk://#diff-f85de29e6240ad157c554a7fc3f6458b3f841008e21244d9e717f688ebc51e4fL171-R179">[5]</a> <a href="diffhunk://#diff-f85de29e6240ad157c554a7fc3f6458b3f841008e21244d9e717f688ebc51e4fR113-R114">[6]</a> <a href="diffhunk://#diff-f85de29e6240ad157c554a7fc3f6458b3f841008e21244d9e717f688ebc51e4fL48-R50">[7]</a> <a href="diffhunk://#diff-f85de29e6240ad157c554a7fc3f6458b3f841008e21244d9e717f688ebc51e4fR65-R66">[8]</a> <a href="diffhunk://#diff-f85de29e6240ad157c554a7fc3f6458b3f841008e21244d9e717f688ebc51e4fR151-R152">[9]</a> <a href="diffhunk://#diff-f85de29e6240ad157c554a7fc3f6458b3f841008e21244d9e717f688ebc51e4fL226-R236">[10]</a> <a href="diffhunk://#diff-f85de29e6240ad157c554a7fc3f6458b3f841008e21244d9e717f688ebc51e4fL160-R169">[11]</a> <a href="diffhunk://#diff-f85de29e6240ad157c554a7fc3f6458b3f841008e21244d9e717f688ebc51e4fL277-R291">[12]</a> <a href="diffhunk://#diff-f85de29e6240ad157c554a7fc3f6458b3f841008e21244d9e717f688ebc51e4fL195-R210">[13]</a> <a href="diffhunk://#diff-f85de29e6240ad157c554a7fc3f6458b3f841008e21244d9e717f688ebc51e4fR79-R103">[14]</a>

Other important changes:

* <a href="diffhunk://#diff-47cff59814e294c805181abbdbfd0ce630f120d603eb6df2556e5101e5d2363eL42-L49">`UI/Pages/Admin.razor`</a>: Updated the links for editing vinyls, orders, and genres in the `Admin` page to reflect changes in the routes for editing these entities.
* <a href="diffhunk://#diff-d41ffb35699c9df550f9e2f3ca1f90de02f4192fa995bfa9cfcfe2e55d0306ddL3-R3">`UI/Shared/NavMenu.razor`</a>: Updated the navbar brand text to "MelodyMine" and added new menu items for "Vinyls", "Admin", and "Shopping cart" with corresponding icons. <a href="diffhunk://#diff-d41ffb35699c9df550f9e2f3ca1f90de02f4192fa995bfa9cfcfe2e55d0306ddL3-R3">[1]</a> <a href="diffhunk://#diff-d41ffb35699c9df550f9e2f3ca1f90de02f4192fa995bfa9cfcfe2e55d0306ddL19-R29">[2]</a>

Note: Due to the length and complexity of the changes, the list of important changes has been truncated. Please refer to the original pull request for the complete list of changes.