### PR TITLE
Implement searching for vinyls

### DIFF
--- a/UI/Pages/Shop.razor
+++ b/UI/Pages/Shop.razor
@@ -8,9 +8,14 @@
 
 <p>Use this page for shopping Vinyls!</p>
 
+<div class="row">
+    <div class="col-lg-6 offset-lg-3">
+        <input type="text" @bind="searchTerm" @bind:event="oninput" placeholder="Search..." class="form-control mb-3" />
+    </div>
+</div>
 <div class="container-fluid mt-4">
     <div class="row">
-        @foreach (var vinyl in _vinyls)
+        @foreach (var vinyl in filteredVinyls)
         {
             <div class="col-lg-3 my-2">
                 <div class="card">
@@ -38,6 +43,10 @@
 @code {
     [Inject] private ILogger<Shop> _logger { get; init; } = default!;
     private List<VinylDto> _vinyls = new List<VinylDto>();
+    private string searchTerm = string.Empty;
+
+    private IEnumerable<VinylDto> filteredVinyls => _vinyls
+        .Where(vinyl => string.IsNullOrEmpty(searchTerm) || vinyl.Title.Contains(searchTerm, StringComparison.OrdinalIgnoreCase));
 
     protected override async Task OnInitializedAsync()
     {


### PR DESCRIPTION
This pull request adds a new search functionality to the `Shop` component in the `UI/Pages/Shop.razor` file. It introduces a new private field called `searchTerm` and adds an input element for searching vinyls, with the `searchTerm` field bound to its value using the `@bind` directive.

Main changes:

* <a href="diffhunk://#diff-5ad0c271141fb3aa9ec62c1e4940be9f5ccdf004ade48a2aa8fa0e15048b723eR11-R18">`UI/Pages/Shop.razor`</a>: Added a new private field `searchTerm` and an input element for searching vinyls, with the `searchTerm` field bound to its value.